### PR TITLE
Fix TOML not loading properly

### DIFF
--- a/fake_bme280/basic.py
+++ b/fake_bme280/basic.py
@@ -27,6 +27,7 @@ Implementation Notes
 """
 import math
 import os
+import toml
 import socket as pool
 import ssl
 import typing  # pylint: disable=unused-import
@@ -75,17 +76,19 @@ _BME280_REGISTER_CONFIG = const(0xF5)
 _BME280_REGISTER_TEMPDATA = const(0xFA)
 _BME280_REGISTER_HUMIDDATA = const(0xFD)
 
+# Load the settings.toml file
+config = toml.load("settings.toml")
+
 # OpenWeatherMap API
 # GET weather data for a specific location
-# TODO: this could be cleaned up a bit..
 DATA_SOURCE = (
     "http://api.openweathermap.org/data/2.5/weather?q="
-    + os.getenv("openweather_location")
+    + config["openweather_location"]
     + "&units="
-    + os.getenv("openweather_units")
+    + config["openweather_units"]
     + "&mode=json"
     + "&appid="
-    + os.getenv("openweather_token")
+    + config["openweather_token"]
 )
 
 
@@ -113,11 +116,6 @@ class Adafruit_BME280:
         self.sea_level_pressure = 1013.25
         """Pressure in hectoPascals at sea level. Used to calibrate `altitude`."""
         self._t_fine = None
-        # Configure OpenWeather for mock data
-        self.openweather_token = os.getenv("OPENWEATHER_TOKEN", "default_token")
-        self.openweather_location = os.getenv(
-            "OPENWEATHER_LOCATION", "default_location"
-        )
         # Configure a CPython adafruit_requests session
         self.requests = adafruit_requests.Session(pool, ssl.create_default_context())
         self._current_forcast = None

--- a/fake_bme280/basic.py
+++ b/fake_bme280/basic.py
@@ -26,11 +26,10 @@ Implementation Notes
   https://circuitpython.org/downloads
 """
 import math
-import os
-import toml
 import socket as pool
 import ssl
 import typing  # pylint: disable=unused-import
+import toml
 from micropython import const
 import adafruit_requests
 from fake_bme280.protocol import I2C_Impl, SPI_Impl
@@ -77,18 +76,18 @@ _BME280_REGISTER_TEMPDATA = const(0xFA)
 _BME280_REGISTER_HUMIDDATA = const(0xFD)
 
 # Load the settings.toml file
-config = toml.load("settings.toml")
+toml_config = toml.load("settings.toml")
 
 # OpenWeatherMap API
 # GET weather data for a specific location
 DATA_SOURCE = (
     "http://api.openweathermap.org/data/2.5/weather?q="
-    + config["openweather_location"]
+    + toml_config["openweather_location"]
     + "&units="
-    + config["openweather_units"]
+    + toml_config["openweather_units"]
     + "&mode=json"
     + "&appid="
-    + config["openweather_token"]
+    + toml_config["openweather_token"]
 )
 
 

--- a/fake_bme280/protocol.py
+++ b/fake_bme280/protocol.py
@@ -10,7 +10,7 @@ from digitalio import DigitalInOut
 class I2C_Impl:
     "Protocol implementation for the I2C bus."
 
-    # pylint: disable=too-few-public-methods
+    # pylint: disable=too-few-public-methods, unused-argument, unused-import
     def __init__(self, i2c: I2C, address: int) -> None:
         from adafruit_bus_device import (  # pylint: disable=import-outside-toplevel
             i2c_device,

--- a/fake_bme280/protocol.py
+++ b/fake_bme280/protocol.py
@@ -16,7 +16,7 @@ class I2C_Impl:
             i2c_device,
         )
 
-        self._i2c = i2c_device.I2CDevice(i2c, address)
+        # self._i2c = i2c_device.I2CDevice(i2c, address)
 
 
 class SPI_Impl:


### PR DESCRIPTION
This PR fixes the TOML not loading properly and `AttributeError: 'I2C' object has no attribute 'writeto'` being raised by `protocol.py`